### PR TITLE
.STR black video fix, Windows and Linux CI

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+ROOT_DIR="$(pwd)"
+FFMPEG_VERSION="6.0"
+NUM_JOBS="4"
+
+if [ $# -eq 1 ]; then
+	PACKAGE_NAME="$1"
+	FFMPEG_OPTIONS=""
+	PSXAVENC_OPTIONS=""
+elif [ $# -eq 3 ]; then
+	PACKAGE_NAME="$1"
+	FFMPEG_OPTIONS="--arch=x86 --target-os=mingw32 --cross-prefix=$2-"
+	PSXAVENC_OPTIONS="--cross-file $3"
+else
+	echo "Usage: $0 <package name> [cross prefix] [cross file]"
+	exit 0
+fi
+
+## Download FFmpeg
+
+if [ ! -d ffmpeg-$FFMPEG_VERSION ]; then
+	wget "https://ffmpeg.org/releases/ffmpeg-$FFMPEG_VERSION.tar.xz" \
+		|| exit 1
+	tar Jxf ffmpeg-$FFMPEG_VERSION.tar.xz \
+		|| exit 1
+
+	rm -f ffmpeg-$FFMPEG_VERSION.tar.xz
+fi
+
+## Build FFmpeg
+
+mkdir -p ffmpeg-build
+cd ffmpeg-build
+
+../ffmpeg-$FFMPEG_VERSION/configure \
+	--prefix="$ROOT_DIR/ffmpeg-dist" \
+	$FFMPEG_OPTIONS \
+	--enable-gpl \
+	--enable-version3 \
+	--enable-static \
+	--disable-shared \
+	--enable-small \
+	--disable-programs \
+	--disable-doc \
+	--disable-avdevice \
+	--disable-postproc \
+	--disable-avfilter \
+	--disable-network \
+	--disable-encoders \
+	--disable-hwaccels \
+	--disable-muxers \
+	--disable-bsfs \
+	--disable-devices \
+	--disable-filters \
+	--disable-mmx \
+	|| exit 2
+make -j $NUM_JOBS \
+	|| exit 2
+make install \
+	|| exit 2
+
+cd ..
+rm -rf ffmpeg-build
+
+## Build psxavenc
+
+meson setup \
+	--buildtype release \
+	--strip \
+	--prefix $ROOT_DIR/psxavenc-dist \
+	--pkg-config-path $ROOT_DIR/ffmpeg-dist/lib/pkgconfig \
+	$PSXAVENC_OPTIONS \
+	psxavenc-build \
+	psxavenc \
+	|| exit 3
+meson compile -C psxavenc-build \
+	|| exit 3
+meson install -C psxavenc-build \
+	|| exit 3
+
+rm -rf ffmpeg-dist psxavenc-build
+
+## Package psxavenc
+
+cd psxavenc-dist
+
+zip -9 -r ../$PACKAGE_NAME.zip . \
+	|| exit 4
+
+cd ..
+rm -rf psxavenc-dist

--- a/.github/scripts/mingw-cross.txt
+++ b/.github/scripts/mingw-cross.txt
@@ -1,0 +1,12 @@
+[binaries]
+c         = 'x86_64-w64-mingw32-gcc'
+cpp       = 'x86_64-w64-mingw32-g++'
+ar        = 'x86_64-w64-mingw32-ar'
+strip     = 'x86_64-w64-mingw32-strip'
+pkgconfig = 'pkg-config'
+
+[host_machine]
+system     = 'windows'
+cpu_family = 'x86_64'
+cpu        = 'x86_64'
+endian     = 'little'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,17 +22,21 @@ jobs:
       run: |
         psxavenc/.github/scripts/build.sh psxavenc-windows x86_64-w64-mingw32 psxavenc/.github/scripts/mingw-cross.txt
 
+    - name: Upload Windows build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: psxavenc-windows
+        path: psxavenc-windows.zip
+
     - name: Build psxavenc for Linux
       run: |
         psxavenc/.github/scripts/build.sh psxavenc-linux
 
-    - name: Upload build artifacts
+    - name: Upload Linux build artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: psxavenc-windows
-        path: |
-          psxavenc-windows.zip
-          psxavenc-linux.zip
+        name: psxavenc-linux
+        path: psxavenc-linux.zip
 
     - name: Publish release
       if:   ${{ github.ref_type == 'tag' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+
+name: Build psxavenc
+on:   [ push, pull_request ]
+
+jobs:
+  build:
+    name:    Build and create release
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install prerequisites
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y --no-install-recommends meson ninja-build gcc-mingw-w64-x86-64
+
+    - name: Fetch repo contents
+      uses: actions/checkout@v3
+      with:
+        path: psxavenc
+
+    - name: Build psxavenc for Windows
+      run: |
+        psxavenc/.github/scripts/build.sh psxavenc-windows x86_64-w64-mingw32 psxavenc/.github/scripts/mingw-cross.txt
+
+    - name: Build psxavenc for Linux
+      run: |
+        psxavenc/.github/scripts/build.sh psxavenc-linux
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: psxavenc-windows
+        path: |
+          psxavenc-windows.zip
+          psxavenc-linux.zip
+
+    - name: Publish release
+      if:   ${{ github.ref_type == 'tag' }}
+      uses: softprops/action-gh-release@v1
+      with:
+        #fail_on_unmatched_files: true
+        files: |
+          psxavenc-windows.zip
+          psxavenc-linux.zip

--- a/psxavenc/common.h
+++ b/psxavenc/common.h
@@ -69,7 +69,6 @@ typedef struct {
 } vid_encoder_state_t;
 
 typedef struct {
-	int video_frame_src_size;
 	int video_frame_dst_size;
 	int audio_stream_index;
 	int video_stream_index;

--- a/psxavenc/decoding.c
+++ b/psxavenc/decoding.c
@@ -48,7 +48,6 @@ bool open_av_data(const char *filename, settings_t *settings, bool use_audio, bo
 	av_decoder_state_t* av = &(settings->decoder_state_av);
 	av->video_next_pts = 0.0;
 	av->frame = NULL;
-	av->video_frame_src_size = 0;
 	av->video_frame_dst_size = 0;
 	av->audio_stream_index = -1;
 	av->video_stream_index = -1;
@@ -202,8 +201,13 @@ bool open_av_data(const char *filename, settings_t *settings, bool use_audio, bo
 			NULL,
 			NULL
 		);
-		// Is this even necessary? -- spicyjpeg
-		sws_setColorspaceDetails(
+		if (av->scaler == NULL) {
+			return false;
+		}
+#if 0
+		// FIXME: if this is uncommented libswscale may produce completely black
+		// frames for whatever reason...
+		if (sws_setColorspaceDetails(
 			av->scaler,
 			sws_getCoefficients(av->video_codec_context->colorspace),
 			(av->video_codec_context->color_range == AVCOL_RANGE_JPEG),
@@ -212,14 +216,16 @@ bool open_av_data(const char *filename, settings_t *settings, bool use_audio, bo
 			0,
 			0,
 			0
-		);
+		) < 0) {
+			return false;
+		}
+#endif
 		if (settings->swscale_options) {
 			if (av_opt_set_from_string(av->scaler, settings->swscale_options, NULL, "=", ":,") < 0) {
 				return false;
 			}
 		}
 
-		av->video_frame_src_size = 4*av->video_codec_context->width*av->video_codec_context->height;
 		av->video_frame_dst_size = 3*settings->video_width*settings->video_height/2;
 	}
 

--- a/psxavenc/filefmt.c
+++ b/psxavenc/filefmt.c
@@ -363,7 +363,7 @@ void encode_file_sbs(settings_t *settings, FILE *output) {
 	settings->state_vid.frame_max_size = settings->alignment;
 	settings->state_vid.quant_scale_sum = 0;
 
-	for (int j = 0; ensure_av_data(settings, 0, 1); j++) {
+	for (int j = 0; ensure_av_data(settings, 0, 2); j++) {
 		encode_frame_bs(settings->video_frames, settings);
 		fwrite(settings->state_vid.frame_output, settings->alignment, 1, output);
 


### PR DESCRIPTION
This PR fixes a regression I had previously introduced in the .STR video encoder. It turns out that the call to `sws_setColorspaceDetails()` I had added seems to make libswscale nonfunctional in some cases, to the point of making it output completely black frames. I did try to tweak the parameters to no avail, so the "fix" I came up with is to simply comment it out. This may or may not affect the output (as libswscale otherwise has no way of knowing the source and destination's color ranges) but I could not figure out any other way to get it to work.

I have also added a shell script (`.github/scripts/build.sh`) and GitHub Actions CI configuration to build psxavenc for Windows and Linux and automatically publish binary releases whenever a tag is created. A custom statically linked FFmpeg build is used, making the executables completely self-contained. I ended up cross-compiling for Windows under Linux, which is both faster than building under MSys2 and sidesteps every issue I encountered with it.