### PR TITLE
libpsxav: fix EOF flag being misapplied in xa/xacd output

### DIFF
--- a/libpsxav/adpcm.c
+++ b/libpsxav/adpcm.c
@@ -242,7 +242,7 @@ static void psx_audio_xa_encode_init_sector(psx_cdrom_sector_mode2_t *buffer, ps
 		memset(buffer->sync + 1, 0xFF, 10);
 		buffer->header.mode = 0x02;
 	} else {
-		memset(buffer->subheader, 0, PSX_CDROM_SECTOR_SIZE);
+		memset(buffer->subheader, 0, PSX_CDROM_SECTOR_SIZE - 16);
 	}
 
 	buffer->subheader[0].file = settings.file_number;

--- a/libpsxav/libpsxav.h
+++ b/libpsxav/libpsxav.h
@@ -79,6 +79,58 @@ void psx_audio_spu_set_flag_at_sample(uint8_t* spu_data, int sample_pos, int fla
 
 #define PSX_CDROM_SECTOR_SIZE 2352
 
+typedef struct {
+	uint8_t minute;
+	uint8_t second;
+	uint8_t sector;
+	uint8_t mode;
+} psx_cdrom_sector_header_t;
+
+typedef struct {
+	uint8_t file;
+	uint8_t channel;
+	uint8_t submode;
+	uint8_t coding;
+} psx_cdrom_sector_xa_subheader_t;
+
+typedef struct {
+	uint8_t sync[12];
+	psx_cdrom_sector_header_t header;
+	uint8_t data[0x920];
+} psx_cdrom_sector_mode1_t;
+
+typedef struct {
+	uint8_t sync[12];
+	psx_cdrom_sector_header_t header;
+	psx_cdrom_sector_xa_subheader_t subheader[2];
+	uint8_t data[0x918];
+} psx_cdrom_sector_mode2_t;
+
+_Static_assert(sizeof(psx_cdrom_sector_mode1_t) == PSX_CDROM_SECTOR_SIZE, "Invalid Mode1 sector size");
+_Static_assert(sizeof(psx_cdrom_sector_mode2_t) == PSX_CDROM_SECTOR_SIZE, "Invalid Mode2 sector size");
+
+#define PSX_CDROM_SECTOR_XA_CHANNEL_MASK 0x1F
+
+#define PSX_CDROM_SECTOR_XA_SUBMODE_EOR     0x01
+#define PSX_CDROM_SECTOR_XA_SUBMODE_VIDEO   0x02
+#define PSX_CDROM_SECTOR_XA_SUBMODE_AUDIO   0x04
+#define PSX_CDROM_SECTOR_XA_SUBMODE_DATA    0x08
+#define PSX_CDROM_SECTOR_XA_SUBMODE_TRIGGER 0x10
+#define PSX_CDROM_SECTOR_XA_SUBMODE_FORM2   0x20
+#define PSX_CDROM_SECTOR_XA_SUBMODE_RT      0x40
+#define PSX_CDROM_SECTOR_XA_SUBMODE_EOF     0x80
+
+#define PSX_CDROM_SECTOR_XA_CODING_MONO         0x00
+#define PSX_CDROM_SECTOR_XA_CODING_STEREO       0x01
+#define PSX_CDROM_SECTOR_XA_CODING_CHANNEL_MASK 0x03
+#define PSX_CDROM_SECTOR_XA_CODING_FREQ_DOUBLE  0x00
+#define PSX_CDROM_SECTOR_XA_CODING_FREQ_SINGLE  0x04
+#define PSX_CDROM_SECTOR_XA_CODING_FREQ_MASK    0x0C
+#define PSX_CDROM_SECTOR_XA_CODING_BITS_4       0x00
+#define PSX_CDROM_SECTOR_XA_CODING_BITS_8       0x10
+#define PSX_CDROM_SECTOR_XA_CODING_BITS_MASK    0x30
+#define PSX_CDROM_SECTOR_XA_CODING_EMPHASIS     0x40
+
 typedef enum {
 	PSX_CDROM_SECTOR_TYPE_MODE1,
 	PSX_CDROM_SECTOR_TYPE_MODE2_FORM1,

--- a/psxavenc/cdrom.c
+++ b/psxavenc/cdrom.c
@@ -23,23 +23,22 @@ freely, subject to the following restrictions:
 
 #include "common.h"
 
-void init_sector_buffer_video(uint8_t *buffer, settings_t *settings) {
-	int offset;
+void init_sector_buffer_video(psx_cdrom_sector_mode2_t *buffer, settings_t *settings) {
 	if (settings->format == FORMAT_STR2CD) {
-		memset(buffer, 0, 2352);
-		memset(buffer+0x001, 0xFF, 10);
-		buffer[0x00F] = 0x02;
-		offset = 0x10;
+		memset(buffer, 0, PSX_CDROM_SECTOR_SIZE);
+		memset(buffer->sync + 1, 0xFF, 10);
+		buffer->header.mode = 0x02;
 	} else {
-		memset(buffer, 0, 2336);
-		offset = 0;
+		memset(buffer->subheader, 0, PSX_CDROM_SECTOR_SIZE);
 	}
 
-	buffer[offset+0] = settings->file_number;
-	buffer[offset+1] = settings->channel_number & 0x1F;
-	buffer[offset+2] = 0x08 | 0x40;
-	buffer[offset+3] = 0x00;
-	memcpy(buffer + offset + 4, buffer + offset, 4);
+	buffer->subheader[0].file = settings->file_number;
+	buffer->subheader[0].channel = settings->channel_number & PSX_CDROM_SECTOR_XA_CHANNEL_MASK;
+	buffer->subheader[0].submode =
+		PSX_CDROM_SECTOR_XA_SUBMODE_DATA
+		| PSX_CDROM_SECTOR_XA_SUBMODE_RT;
+	buffer->subheader[0].coding = 0;
+	memcpy(buffer->subheader + 1, buffer->subheader, sizeof(psx_cdrom_sector_xa_subheader_t));
 }
 
 void calculate_edc_data(uint8_t *buffer)

--- a/psxavenc/cdrom.c
+++ b/psxavenc/cdrom.c
@@ -29,7 +29,7 @@ void init_sector_buffer_video(psx_cdrom_sector_mode2_t *buffer, settings_t *sett
 		memset(buffer->sync + 1, 0xFF, 10);
 		buffer->header.mode = 0x02;
 	} else {
-		memset(buffer->subheader, 0, PSX_CDROM_SECTOR_SIZE);
+		memset(buffer->subheader, 0, PSX_CDROM_SECTOR_SIZE - 16);
 	}
 
 	buffer->subheader[0].file = settings->file_number;

--- a/psxavenc/common.h
+++ b/psxavenc/common.h
@@ -124,7 +124,7 @@ typedef struct {
 } settings_t;
 
 // cdrom.c
-void init_sector_buffer_video(uint8_t *buffer, settings_t *settings);
+void init_sector_buffer_video(psx_cdrom_sector_mode2_t *buffer, settings_t *settings);
 void calculate_edc_data(uint8_t *buffer);
 
 // decoding.c

--- a/psxavenc/filefmt.c
+++ b/psxavenc/filefmt.c
@@ -306,7 +306,7 @@ void encode_file_str(settings_t *settings, FILE *output) {
 
 		if ((j%interleave) < video_sectors_per_block) {
 			// Video sector
-			init_sector_buffer_video(buffer, settings);
+			init_sector_buffer_video((psx_cdrom_sector_mode2_t*) buffer, settings);
 			encode_sector_str(settings->video_frames, buffer, settings);
 		} else {
 			// Audio sector
@@ -342,7 +342,7 @@ void encode_file_str(settings_t *settings, FILE *output) {
 			}
 		}
 
-		fwrite(buffer, sector_size, 1, output);
+		fwrite(buffer + 2352 - sector_size, sector_size, 1, output);
 
 		time_t t = get_elapsed_time(settings);
 		if (t) {

--- a/psxavenc/filefmt.c
+++ b/psxavenc/filefmt.c
@@ -333,13 +333,10 @@ void encode_file_str(settings_t *settings, FILE *output) {
 			buffer[0x00C] = ((t/75/60)%10)|(((t/75/60)/10)<<4);
 			buffer[0x00D] = (((t/75)%60)%10)|((((t/75)%60)/10)<<4);
 			buffer[0x00E] = ((t%75)%10)|(((t%75)/10)<<4);
+		}
 
-			// FIXME: EDC is not calculated in 2336-byte sector mode (shouldn't
-			// matter anyway, any CD image builder will have to recalculate it
-			// due to the sector's MSF changing)
-			if((j%interleave) < video_sectors_per_block) {
-				calculate_edc_data(buffer);
-			}
+		if((j%interleave) < video_sectors_per_block) {
+			calculate_edc_data(buffer);
 		}
 
 		fwrite(buffer + 2352 - sector_size, sector_size, 1, output);

--- a/psxavenc/mdec.c
+++ b/psxavenc/mdec.c
@@ -614,13 +614,8 @@ void encode_sector_str(uint8_t *video_frames, uint8_t *output, settings_t *setti
 	header[0x00E] = (uint8_t)(settings->state_vid.bytes_used>>16);
 	header[0x00F] = (uint8_t)(settings->state_vid.bytes_used>>24);
 
-	if (settings->format == FORMAT_STR2CD) {
-		memcpy(output + 0x018, header, sizeof(header));
-		memcpy(output + 0x018 + 0x020, settings->state_vid.frame_output + settings->state_vid.frame_data_offset, 2016);
-	} else {
-		memcpy(output + 0x008, header, sizeof(header));
-		memcpy(output + 0x008 + 0x020, settings->state_vid.frame_output + settings->state_vid.frame_data_offset, 2016);
-	}
+	memcpy(output + 0x018, header, sizeof(header));
+	memcpy(output + 0x018 + 0x020, settings->state_vid.frame_output + settings->state_vid.frame_data_offset, 2016);
 
 	settings->state_vid.frame_data_offset += 2016;
 }


### PR DESCRIPTION
Based on https://github.com/spicyjpeg/psxavenc/commit/9b876b1958f9f719b3c8cf74fe3cedf8b9e89f29

Paging @spicyjpeg for a review