### PR TITLE
Fix uninitialized coding flags when using PSX_AUDIO_XA_FORMAT_XA

### DIFF
--- a/libpsxav/adpcm.c
+++ b/libpsxav/adpcm.c
@@ -266,6 +266,8 @@ static inline void psx_audio_xa_sync_subheader_copy(psx_cdrom_sector_mode2_t *bu
 static void psx_audio_xa_encode_init_sector(psx_cdrom_sector_mode2_t *buffer, int lba, psx_audio_xa_settings_t settings) {
 	if (settings.format == PSX_AUDIO_XA_FORMAT_XACD)
 		psx_cdrom_init_sector((psx_cdrom_sector_t *)buffer, lba, PSX_CDROM_SECTOR_TYPE_MODE2_FORM2);
+	else if (settings.format == PSX_AUDIO_XA_FORMAT_XA)
+		psx_cdrom_init_xa_subheader(buffer->subheader, PSX_CDROM_SECTOR_TYPE_MODE2_FORM2);
 
 	buffer->subheader[0].file = settings.file_number;
 	buffer->subheader[0].channel = settings.channel_number & PSX_CDROM_SECTOR_XA_CHANNEL_MASK;


### PR DESCRIPTION
When using format `PSX_AUDIO_XA_FORMAT_XACD`, `psx_audio_xa_encode_init_sector` calls `psx_cdrom_init_sector`, which calls `psx_cdrom_init_xa_subheader`, which zeroes out the subheader. But when using `PSX_AUDIO_XA_FORMAT_XA`, `psx_audio_xa_encode_init_sector` doesn't call either init function, which leaves `coding` uninitialized. All of the other subheader fields are assigned directly, so they aren't affected, but `coding` is only OR'd with flags, so it can become corrupted. This could be fixed just by changing the first OR with an assignment, but this PR instead calls `psx_cdrom_init_xa_subheader` directly when the format is `PSX_AUDIO_XA_FORMAT_XA`.